### PR TITLE
Dealing better with PTMs, better evaluation logic and other patches

### DIFF
--- a/docs/md_simulation_methodology.md
+++ b/docs/md_simulation_methodology.md
@@ -85,7 +85,7 @@ RESP charges are specifically parameterized to work synergistically with the oth
 
 | Parameter | Value | Description |
 |-----------|-------|-------------|
-| Temperature | 300 K | Simulation temperature |
+| Temperature | 310.15 K (37 C) | Simulation temperature |
 | Pressure | 1 atm | Simulation pressure |
 | Timestep | 2 fs | Integration timestep |
 | Integrator | Langevin Middle | With 1 $ps^{-1}$ friction |
@@ -131,7 +131,7 @@ The system's potential energy is minimized by adjusting atomic positions until f
 | Reporting interval | 5,000 steps (10 ps) |
 | Constraints | Alpha-carbon (CA) position restraints (1000 kJ/mol/nm²) |
 
-The Monte Carlo Barostat adjusts the simulation box volume to maintain constant pressure. Alpha-carbon atoms are restrained to their initial positions using harmonic restraints with a force constant of **1000 kJ/mol/nm²** to prevent large-scale protein conformational changes during equilibration while allowing side chains and solvent to relax.
+The Monte Carlo Barostat adjusts the simulation box volume to maintain constant pressure. Alpha-carbon atoms are restrained using Cartesian harmonic restraints with a force constant of **1000 kJ/mol/nm²** to prevent large-scale protein conformational changes during equilibration while allowing side chains and solvent to relax. After each monitoring chunk, the CA reference positions are updated to the current (in-box) coordinates so that the harmonic restraints track the barostat coordinate rescaling rather than accumulating an artificial restoring force against the original positions.
 
 ---
 
@@ -448,21 +448,35 @@ NPT equilibration complete.
 
 ### Appendix B: Alpha-Carbon Restraint Implementation
 
-During energy minimization, NPT equilibration, and NVT equilibration, alpha-carbon (CA) atoms are restrained to their initial positions using OpenMM's [3] `CustomExternalForce` with a harmonic restraint potential that is periodic boundary condition (PBC) aware:
+During energy minimization, NPT equilibration, and NVT equilibration, alpha-carbon (CA) atoms are restrained using OpenMM's [3] `CustomExternalForce` with a **Cartesian harmonic** potential:
 
-$$U_{restraint} = k \cdot d_{PBC}^2$$
+$$U_{restraint} = \frac{1}{2} k \left[(x - x_0)^2 + (y - y_0)^2 + (z - z_0)^2\right]$$
 
 Where:
 - $k$ = 1000 kJ/mol/nm² (force constant)
-- $d_{PBC}$ = minimum-image distance to reference position $(x_0, y_0, z_0)$
+- $(x_0, y_0, z_0)$ = per-particle reference position in nanometers
+
+A Cartesian harmonic form is used instead of `periodicdistance` because the gradient of `periodicdistance` is discontinuous at periodic box boundaries. When a CA atom's minimum image flips, the gradient direction reverses instantaneously, producing a large impulsive force that can drive the simulation to NaN — especially during NPT where the box is actively changing.
+
+**NPT reference-position tracking**: The Monte Carlo Barostat accepts trial volume changes by rescaling all particle coordinates proportionally, but does *not* update per-particle parameters in `CustomExternalForce`. Without correction, the mismatch between rescaled coordinates and fixed reference positions creates a growing artificial restoring force. To prevent this, after each monitoring chunk the CA reference positions are updated to the current in-box coordinates before the next chunk runs:
+
+```python
+# Update reference positions to track barostat coordinate rescaling
+pos_state = context.getState(getPositions=True, enforcePeriodicBox=True)
+current_positions = pos_state.getPositions()
+for i, atom_idx in enumerate(ca_indices):
+    pos = list(current_positions[atom_idx].value_in_unit(nanometers))
+    restraint_force.setParticleParameters(i, atom_idx, pos)
+restraint_force.updateParametersInContext(context)
+```
 
 **Implementation**:
 ```python
 # Get indices of CA atoms
 ca_indices = [atom.index for atom in topology.atoms() if atom.name == 'CA']
 
-# Custom external force to restrain CA atoms to their initial positions
-restraint_force = CustomExternalForce("k*periodicdistance(x, y, z, x0, y0, z0)^2")
+# Cartesian harmonic restraint — numerically stable across box boundaries
+restraint_force = CustomExternalForce("0.5*k*((x-x0)^2 + (y-y0)^2 + (z-z0)^2)")
 
 # Add per-particle parameters for reference positions
 restraint_force.addPerParticleParameter('x0') # reference x

--- a/proteogram/common/constants.py
+++ b/proteogram/common/constants.py
@@ -21,6 +21,46 @@ RESIDUE_LIST = [
     ("V", "VAL"),
 ]
 
+MODIFIED_RESIDUES_TO_STANDARD = {
+            # Methionine variants
+            'MSE': 'MET',  # Selenomethionine
+            'FME': 'MET',  # N-formylmethionine
+            'CXM': 'MET',  # N-carboxymethionine
+            # Lysine variants
+            'M3L': 'LYS',  # N6,N6,N6-trimethyllysine
+            'MLY': 'LYS',  # N6-methyllysine
+            'MLZ': 'LYS',  # N6-methyllysine (alt code)
+            'KCX': 'LYS',  # Lysine NZ-carboxylic acid
+            'ALY': 'LYS',  # N6-acetyllysine
+            'LLP': 'LYS',  # Lysine-pyridoxal-5-phosphate
+            # Cysteine variants
+            'CSO': 'CYS',  # S-hydroxycysteine
+            'CME': 'CYS',  # S,S-(2-hydroxyethyl)thiocysteine
+            'OCS': 'CYS',  # Cysteinesulfonic acid
+            'SEC': 'CYS',  # Selenocysteine
+            'SMC': 'CYS',  # S-methylcysteine
+            'CSD': 'CYS',  # 3-sulfoalanine (treated as Cys)
+            # Serine/Threonine variants
+            'SEP': 'SER',  # Phosphoserine
+            'TPO': 'THR',  # Phosphothreonine
+            # Tyrosine variants
+            'PTR': 'TYR',  # Phosphotyrosine
+            'TYS': 'TYR',  # Sulfotyrosine
+            # Proline variants
+            'HYP': 'PRO',  # 4-hydroxyproline
+            # Aspartate variants
+            'BHD': 'ASP',  # (3S)-3-hydroxy-L-aspartic acid (beta-hydroxyaspartic acid)
+            # Glutamate/Glutamine variants
+            'CGU': 'GLU',  # Gamma-carboxyglutamate
+            'PCA': 'GLN',  # Pyroglutamate (from Gln)
+            # Histidine variants
+            'NEP': 'HIS',  # N1-phosphohistidine
+            'HIC': 'HIS',  # 4-methyl-histidine
+        }
+
+# Solvent residue names to exclude when parsing PDB files. This is not an exhaustive list, but covers common cases.
+SOLVENT_RESIDUES = {'HOH', 'WAT', 'TIP3', 'SOL', 'NA', 'CL', 'K', 'MG', 'ZN'}
+
 UNKNOWN_RESIDUE = ("X", "UNK")
 
 BACKBONE_ATOMS = ["N", "CA", "C"]

--- a/proteogram/v2/nonbonded_forces.py
+++ b/proteogram/v2/nonbonded_forces.py
@@ -31,6 +31,8 @@ from typing import Optional
 from pathlib import Path
 import psutil
 
+from ..common.constants import MODIFIED_RESIDUES_TO_STANDARD, SOLVENT_RESIDUES
+
 
 class NonBondedForceModel:
     """Model for computing non-bonded forces between residues using MD simulation.
@@ -168,6 +170,24 @@ class NonBondedForceModel:
         fixer.findMissingResidues()
         fixer.findNonstandardResidues()
         fixer.replaceNonstandardResidues()
+
+        # Rename any modified residues that PDBFixer didn't handle BEFORE calling
+        # removeHeterogens. Modified residues are stored as HETATM records in PDB
+        # files, so removeHeterogens would silently delete them if they haven't
+        # already been converted to a standard residue name.
+        _MODIFIED_TO_STANDARD = {
+            'MSE': 'MET', 'FME': 'MET', 'CXM': 'MET',
+            'M3L': 'LYS', 'MLY': 'LYS', 'MLZ': 'LYS', 'KCX': 'LYS', 'ALY': 'LYS', 'LLP': 'LYS',
+            'CSO': 'CYS', 'CME': 'CYS', 'OCS': 'CYS', 'SEC': 'CYS', 'SMC': 'CYS', 'CSD': 'CYS',
+            'SEP': 'SER', 'TPO': 'THR', 'PTR': 'TYR', 'TYS': 'TYR',
+            'HYP': 'PRO', 'CGU': 'GLU', 'PCA': 'GLN', 'NEP': 'HIS', 'HIC': 'HIS',
+            'BHD': 'ASP',
+        }
+        for res in fixer.topology.residues():
+            if res.name in _MODIFIED_TO_STANDARD:
+                print(f"  INFO: Pre-renaming {res.name} → {_MODIFIED_TO_STANDARD[res.name]} before hetatm removal")
+                res.name = _MODIFIED_TO_STANDARD[res.name]
+
         fixer.removeHeterogens(keepWater=False)
         fixer.findMissingAtoms()
         fixer.addMissingAtoms()
@@ -207,7 +227,31 @@ class NonBondedForceModel:
         # Handle modified amino acids that OpenMM doesn't recognize
         # Replace them with their standard equivalents before solvation
         self._replace_modified_residues()
-        
+
+        # Remove any non-standard heavy atoms that were part of a modified residue
+        # (e.g. M3L's trimethyl carbons after renaming to LYS).  These atoms are
+        # not in the AMBER template and would cause createSystem() to fail.
+        self._delete_extra_atoms_from_templates()
+
+        # Strip ALL existing H from the topology and re-add via addHydrogens.
+        # This handles two classes of wrong H:
+        #   1. H on modified residues that PDBFixer placed incorrectly after
+        #      partial conversion (e.g. H-O on CSO's OD after OD is deleted).
+        #   2. H on standard residues that were in the raw PDB with the wrong
+        #      protonation state — most commonly HXT on C-terminal OXT, which
+        #      is present in many PDB files but should be absent at pH 7.0
+        #      (C-terminal pKa ~3.5).  addHydrogens only *adds* missing H; it
+        #      does not remove existing ones, so we must strip first.
+        all_h = [
+            atom
+            for residue in self.modeller.topology.residues()
+            for atom in residue.atoms()
+            if atom.element is not None and atom.element.symbol == 'H'
+        ]
+        if all_h:
+            self.modeller.delete(all_h)
+        self.modeller.addHydrogens(self.forcefield, pH=7.0)
+
         # Store protein residue indices before adding water
         self._identify_protein_residues()
         
@@ -240,27 +284,88 @@ class NonBondedForceModel:
 
     def _replace_modified_residues(self) -> None:
         """Replace modified amino acids with their standard equivalents.
-        
+
         OpenMM's AMBER force field doesn't have parameters for modified AAs like MSE
         (selenomethionine), so we convert them to standard equivalents before solvation.
-        
+
         This preserves the 3D structure while allowing force field compatibility.
         """
-        # Mapping of modified residues to their standard equivalents
-        residue_replacements = {
-            'MSE': 'MET',  # Selenomethionine -> Methionine
-            'HYP': 'PRO',  # Hydroxyproline -> Proline
-            'PTR': 'TYR',  # Phosphotyrosine -> Tyrosine
-            'SEP': 'SER',  # Phosphoserine -> Serine
-            'TPO': 'THR',  # Phosphothreonine -> Threonine
+        # Atom name remappings required per modified residue.
+        # Renaming the residue alone is insufficient — the force field template
+        # for the standard residue expects different atom names (e.g. MET needs
+        # 'SD' but MSE has 'SE' for the chalcogen).
+        atom_name_fixes = {
+            'MSE': {'SE': 'SD'},  # Selenium -> Sulfur
         }
-        
-        # Iterate through topology and replace residue names
+
+        # Iterate through topology and replace residue names AND atom names
         for residue in self.modeller.topology.residues():
-            if residue.name in residue_replacements:
-                standard_name = residue_replacements[residue.name]
-                print(f"  INFO: Converting {residue.name} (residue {residue.index}) to {standard_name}")
+            if residue.name in MODIFIED_RESIDUES_TO_STANDARD:
+                original_name = residue.name
+                standard_name = MODIFIED_RESIDUES_TO_STANDARD[original_name]
+                print(f"  INFO: Converting {original_name} (residue {residue.index}) to {standard_name}")
                 residue.name = standard_name
+                if original_name in atom_name_fixes:
+                    for atom in residue.atoms():
+                        if atom.name in atom_name_fixes[original_name]:
+                            atom.name = atom_name_fixes[original_name][atom.name]
+
+    def _delete_extra_atoms_from_templates(self) -> None:
+        """Delete non-standard heavy atoms left over from renamed modified residues.
+
+        After renaming a modified residue to its standard equivalent (e.g. M3L → LYS),
+        any atoms that don't belong to the standard AMBER template remain in the topology
+        (e.g. M3L's three trimethyl carbons C7/C8/C9 on NZ). Those extra atoms cause
+        ForceField.createSystem() to fail with "No template found". This method removes
+        them using the force field's own template definitions as the reference.
+
+        Terminal atoms (OXT, OC1, OC2) are explicitly preserved — they are not in the
+        *internal* residue template but are legitimate C-terminal atoms added by PDBFixer.
+        Deleting them would break C-terminal template matching.
+
+        H atoms bonded to deleted heavy atoms are also deleted to avoid dangling
+        hydrogens (e.g. H71/H72/H73 bonded to M3L's C7 after C7 is removed).
+        """
+        # These atom names are legitimate even though they're absent from the
+        # internal residue template (they appear in terminal-residue templates).
+        _PRESERVE = {'OXT', 'OC1', 'OC2', 'HXT'}
+
+        # Pass 1: collect non-standard heavy atoms to remove
+        non_standard_heavy: set = set()
+        for residue in self.modeller.topology.residues():
+            template = self.forcefield._templates.get(residue.name)
+            if template is None:
+                continue
+            template_atom_names = {a.name for a in template.atoms}
+            for atom in residue.atoms():
+                if atom.element is not None and atom.element.symbol == 'H':
+                    continue  # H atoms handled in pass 2
+                if atom.name in _PRESERVE:
+                    continue  # Never delete terminal oxygen/hydrogen atoms
+                if atom.name not in template_atom_names:
+                    non_standard_heavy.add(atom)
+
+        # Pass 2: collect ALL H atoms from any residue that had non-standard heavy
+        # atoms. Removing only the H atoms directly bonded to deleted heavy atoms
+        # is not sufficient: PDBFixer may have placed an H on the modification's
+        # oxygen (e.g. OD in CSO) rather than on SG, leaving a wrong H-O bond after
+        # OD is deleted.  Stripping every H from the affected residues gives
+        # addHydrogens a clean slate so it can re-protonate correctly.
+        affected_residue_indices: set = {atom.residue.index for atom in non_standard_heavy}
+        h_to_delete: set = set()
+        for residue in self.modeller.topology.residues():
+            if residue.index not in affected_residue_indices:
+                continue
+            for atom in residue.atoms():
+                if atom.element is not None and atom.element.symbol == 'H':
+                    if atom.name not in _PRESERVE:
+                        h_to_delete.add(atom)
+
+        atoms_to_delete = list(non_standard_heavy | h_to_delete)
+        if atoms_to_delete:
+            print(f"  INFO: Removing {len(atoms_to_delete)} non-standard/misplaced atom(s) from renamed modified residues "
+                  f"({len(non_standard_heavy)} heavy + {len(h_to_delete)} H from affected residues)")
+            self.modeller.delete(atoms_to_delete)
 
     def _identify_protein_residues(self) -> None:
         """Identify protein residue indices before solvation."""
@@ -268,10 +373,14 @@ class NonBondedForceModel:
             'ALA', 'ARG', 'ASN', 'ASP', 'CYS', 'GLN', 'GLU', 'GLY', 'HIS',
             'ILE', 'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP',
             'TYR', 'VAL', 'HIE', 'HID', 'HIP', 'CYX',
-            # Modified amino acids
-            'MSE',  # Selenomethionine (variant of MET)
-            'PTR', 'SEP', 'TPO',  # Phosphorylated variants
-            'HYP',  # Hydroxyproline (variant of PRO)
+            # Modified amino acids (kept here for the case where _replace_modified_residues
+            # hasn't run yet at identification time)
+            'MSE', 'FME', 'CXM',
+            'M3L', 'MLY', 'MLZ', 'KCX', 'ALY', 'LLP',
+            'CSO', 'CME', 'OCS', 'SEC', 'SMC', 'CSD',
+            'SEP', 'TPO', 'PTR', 'TYS',
+            'HYP', 'CGU', 'PCA', 'NEP', 'HIC',
+            'BHD',
         }
         self.protein_residue_indices = []
         for i, residue in enumerate(self.modeller.topology.residues()):
@@ -365,9 +474,10 @@ class NonBondedForceModel:
             # Get indices of CA atoms
             ca_indices = [atom.index for atom in self.topology.atoms() if atom.name == 'CA']
 
-            # Custom external force to restrain CA atoms to their initial positions
-            # restraint_force = CustomExternalForce("0.5*k*((x-x0)^2 + (y-y0)^2 + (z-z0)^2)")
-            restraint_force = CustomExternalForce("k*periodicdistance(x, y, z, x0, y0, z0)^2")
+            # Cartesian harmonic restraint — avoids periodicdistance discontinuities
+            # and is compatible with NPT barostat coordinate rescaling when reference
+            # positions are updated after each chunk (see equilibrate_npt).
+            restraint_force = CustomExternalForce("0.5*k*((x-x0)^2 + (y-y0)^2 + (z-z0)^2)")
 
             # Add per-particle parameters for reference positions
             restraint_force.addPerParticleParameter('x0') # reference x
@@ -381,6 +491,13 @@ class NonBondedForceModel:
             for idx in ca_indices:
                 restraint_force.addParticle(idx, self.positions[idx].value_in_unit(nanometers))
             system.addForce(restraint_force)
+
+            # Store for reference-position updates during NPT barostat rescaling
+            self._restraint_force = restraint_force
+            self._ca_indices = ca_indices
+        else:
+            self._restraint_force = None
+            self._ca_indices = []
         
         integrator = LangevinMiddleIntegrator(
             self.temperature,
@@ -431,8 +548,12 @@ class NonBondedForceModel:
             self._log_energy('minimization', 0.0, initial_energy)
         
         self.simulation.minimizeEnergy(maxIterations=max_iterations)
-        _st = self.simulation.context.getState(getPositions=True)
+        _st = self.simulation.context.getState(getPositions=True, enforcePeriodicBox=True)
         self.positions = _st.getPositions()
+        try:
+            self._box_vectors = _st.getPeriodicBoxVectors()
+        except Exception:
+            pass
         del _st
         
         # Log final energy after minimization (debug mode)
@@ -454,7 +575,9 @@ class NonBondedForceModel:
 
         This method writes the current positions to an in-memory PDB file
         that can be saved or further processed. Can be called after any
-        simulation step (minimization, equilibration, or production).
+        simulation step (minimization, equilibration, or production). This
+        method strips solvent atoms from the output to focus on the protein
+        structure and interactions.
 
         Returns:
             io.StringIO: An in-memory PDB file containing the current structure.
@@ -471,8 +594,16 @@ class NonBondedForceModel:
                 "No topology available. Run setup_system() first."
             )
 
+        # Create a modeller to strip solvent, then extract topology/positions
+        from openmm.app import Modeller
+        modeller = Modeller(self.topology, self.positions)
+        modeller.delete(
+            atom for atom in self.topology.atoms()
+            if atom.residue.name in SOLVENT_RESIDUES
+        )
+
         pdb_stream = io.StringIO()
-        PDBFile.writeFile(self.topology, self.positions, pdb_stream)
+        PDBFile.writeFile(modeller.topology, modeller.positions, pdb_stream)
         pdb_stream.seek(0)
         return pdb_stream
 
@@ -710,7 +841,7 @@ class NonBondedForceModel:
         state and clean up the state."""
         if self.simulation is not None:
             try:
-                state = self.simulation.context.getState(getPositions=True)
+                state = self.simulation.context.getState(getPositions=True, enforcePeriodicBox=True)
                 self.positions = state.getPositions()
                 try:
                     # Store the periodic box vectors from the state before deleting context
@@ -1002,7 +1133,11 @@ class NonBondedForceModel:
         self._create_new_simulation(
             add_calpha_restraint=True,
             add_barostat=True)
-        
+
+        # Initialize velocities — without this OpenMM starts from zero,
+        # which causes an energy spike with stiff restraints under NPT
+        self.simulation.context.setVelocitiesToTemperature(self.temperature)
+
         # Add reporter for monitoring
         self.simulation.reporters.append(
             StateDataReporter(
@@ -1034,14 +1169,25 @@ class NonBondedForceModel:
         # Log initial energy (debug mode)
         if self.debug:
             self._log_energy('npt', 0.0, initial_energy)
-        
+
         # Run equilibration in chunks for monitoring
         steps_run = 0
         while steps_run < steps:
             chunk = min(check_interval, steps - steps_run)
             self.simulation.step(chunk)
             steps_run += chunk
-            
+
+            # Update CA restraint reference positions to track NPT barostat
+            # coordinate rescaling — prevents growing forces from position/box mismatch
+            if self._restraint_force is not None and self._ca_indices:
+                pos_state = self.simulation.context.getState(getPositions=True, enforcePeriodicBox=True)
+                current_positions = pos_state.getPositions()
+                del pos_state
+                for i, atom_idx in enumerate(self._ca_indices):
+                    pos = list(current_positions[atom_idx].value_in_unit(nanometers))
+                    self._restraint_force.setParticleParameters(i, atom_idx, pos)
+                self._restraint_force.updateParametersInContext(self.simulation.context)
+
             # Get current energy
             state = self.simulation.context.getState(getEnergy=True)
             current_energy = state.getPotentialEnergy().value_in_unit(kilojoules_per_mole)
@@ -1070,7 +1216,7 @@ class NonBondedForceModel:
             f"({final_energy/n_atoms:.2f} kJ/mol/atom)")
         
         # Check for energy explosion (indicates coordinate corruption)
-        if final_energy / n_atoms > 100 or final_energy / n_atoms > 0:
+        if final_energy / n_atoms > 100:
             print(f"WARNING: NPT final energy is unreasonably high ({final_energy/n_atoms:.1f} kJ/mol/atom)")
             print("  This may indicate coordinate corruption in the system")
             # This will be detected and fixed at the start of NVT
@@ -1283,7 +1429,7 @@ class NonBondedForceModel:
         
         # Sanity check: if energy is ridiculously high, coordinates are corrupted
         # Typical folded protein energy is -10 to -30 kJ/mol/atom
-        if initial_energy / n_atoms > 100 or initial_energy / n_atoms > 0:
+        if initial_energy / n_atoms > 100:
             print(f"ERROR: Initial NVT energy is unreasonably high ({initial_energy/n_atoms:.1f} kJ/mol/atom)")
             print("  This indicates corrupted particle coordinates")
             if hasattr(self, '_pre_npt_positions') and self._pre_npt_positions is not None:
@@ -1299,7 +1445,7 @@ class NonBondedForceModel:
                 initial_energy = initial_state.getPotentialEnergy().value_in_unit(kilojoules_per_mole)
                 del initial_state
                 print(f"  Retrying with pre-NPT positions: {initial_energy:.1f} kJ/mol ({initial_energy/n_atoms:.2f} kJ/mol/atom)")
-                if initial_energy / n_atoms > 100 or initial_energy / n_atoms > 0:
+                if initial_energy / n_atoms > 100:
                     raise RuntimeError(f"Even pre-NPT positions are corrupted (energy: {initial_energy/n_atoms:.1f} kJ/mol/atom)")
             else:
                 raise RuntimeError(f"Initial NVT energy is corrupted ({initial_energy/n_atoms:.1f} kJ/mol/atom) and no backup positions available")
@@ -1813,9 +1959,6 @@ class NonBondedForceModel:
                 mem_before_solvent = process.memory_info().rss / 1024 / 1024
             (vdw_solv, es_solv, 
             vdw_force_solv, es_force_solv) = self._calculate_residue_solvent_energies(positions)
-            if self.debug:
-                mem_after_solvent = process.memory_info().rss / 1024 / 1024
-                print(f"Solvent energy computation: {mem_before_solvent:.1f} -> {mem_after_solvent:.1f} MB (delta: {mem_after_solvent - mem_before_solvent:.1f} MB)")
         
         # Energy matrices
         vdw_energy_attractive = np.zeros((n_residues, n_residues))
@@ -1957,9 +2100,6 @@ class NonBondedForceModel:
                         # Subtract from attractive terms (solvent interaction is typically stabilizing)
                         vdw_energy_attractive[i, j] -= avg_vdw_solv
                         es_energy_attractive[i, j] -= avg_es_solv
-                if self.debug:
-                    mem_after_standard = process.memory_info().rss / 1024 / 1024
-                    print(f"Standard solvent subtraction: {mem_before_standard:.1f} -> {mem_after_standard:.1f} MB (delta: {mem_after_standard - mem_before_standard:.1f} MB)")
         
         return (vdw_energy_attractive, vdw_energy_repulsive, es_energy_attractive, es_energy_repulsive)
     

--- a/proteogram/v2/proteogram.py
+++ b/proteogram/v2/proteogram.py
@@ -10,7 +10,7 @@ import gc
 from Bio.PDB.PDBParser import PDBParser, PDBConstructionWarning
 from Bio.PDB.Polypeptide import PPBuilder
 
-from ..common.constants import HYDROPHOBICITY_LIST, RESIDUE_LIST
+from ..common.constants import HYDROPHOBICITY_LIST, RESIDUE_LIST, MODIFIED_RESIDUES_TO_STANDARD
 from .nonbonded_forces import NonBondedForceModel
 
 
@@ -65,12 +65,24 @@ class ProteogramV2:
         self.structure = parser.get_structure("protein_id", self.pdb_path)
         self.model = self.structure[0]
         try:
-            self.chain = self.model[chain_id]
-        except KeyError:
-            raise KeyError(f"Chain ID {chain_id} not found in PDB file.")
+            # Get the first chain from PDB file from the PDBParser structure model
+            self.chain = self.model.get_chains().__next__()
+        except StopIteration as e:
+            raise StopIteration(f"No chains found in PDB file {pdb_path}") from e
         self.allowed_amino_acids = {b: a for a, b in RESIDUE_LIST}
+        # Extend with modified residues. MODIFIED_RESIDUES_TO_STANDARD maps
+        # 3-letter modified codes → 3-letter standard codes ('M3L' → 'LYS').
+        # allowed_amino_acids needs 3-letter → 1-letter ('M3L' → 'K'), so we
+        # compose through the already-built dict to get the right value.
+        self.allowed_amino_acids.update({
+            mod: self.allowed_amino_acids[std]
+            for mod, std in MODIFIED_RESIDUES_TO_STANDARD.items()
+            if std in self.allowed_amino_acids
+        })
         self.sequence = ''.join(
-            [self.allowed_amino_acids[res.resname] for res in self.chain])
+            [self.allowed_amino_acids[res.resname]
+             for res in self.chain
+             if res.resname in self.allowed_amino_acids])
         self.calpha_atom_distance_cutoff = calpha_atom_distance_cutoff
         self.sequence_len_lower_cutoff = sequence_len_lower_cutoff
         self.sequence_len_upper_cutoff = sequence_len_upper_cutoff

--- a/scripts/v2/create_balanced_scope_train_eval_lists.py
+++ b/scripts/v2/create_balanced_scope_train_eval_lists.py
@@ -16,7 +16,8 @@ Usage:
         --train-output train_set.txt \
         --eval-output eval_set.txt \
         [--split-train 10] \
-        [--seed 42]
+        [--seed 42] \
+        [--exclude-classes e,f,g]
 
 Class column options:
     - SCOPeClass: Major structural class (e.g., a, b, c, d)
@@ -290,6 +291,14 @@ def main():
         help='Split training set into N separate files for parallel processing '
              '(e.g., --split-train 10 creates train_part01.txt through train_part10.txt)'
     )
+
+    parser.add_argument(
+        '--split-eval',
+        type=int,
+        default=None,
+        help='Split evaluation set into N separate files '
+             '(e.g., --split-eval 4 creates eval_part01.txt through eval_part04.txt)'
+    )
     
     parser.add_argument(
         '--id-column', '-i',
@@ -303,19 +312,34 @@ def main():
         default=None,
         help='Random seed for reproducibility'
     )
-    
+
+    parser.add_argument(
+        '--exclude-classes',
+        default=None,
+        help='Comma-separated list of class values to exclude (e.g., "e,f,g")'
+    )
+
     args = parser.parse_args()
-    
+
+    exclude_classes = set()
+    if args.exclude_classes:
+        exclude_classes = {c.strip() for c in args.exclude_classes.split(',')}
+
     # Parse the .lst file
     print(f"Reading identifiers from: {args.lst_file}")
     identifiers = parse_lst_file(args.lst_file)
     print(f"Found {len(identifiers)} identifiers in .lst file")
-    
+
     # Load lookup table
     print(f"Loading lookup table from: {args.lookup_tsv}")
     lookup_df = load_lookup_table(args.lookup_tsv, args.class_column)
     print(f"Lookup table has {len(lookup_df)} entries")
-    
+
+    if exclude_classes:
+        before = len(lookup_df)
+        lookup_df = lookup_df[~lookup_df[args.class_column].isin(exclude_classes)]
+        print(f"Excluded classes {sorted(exclude_classes)}: {before} -> {len(lookup_df)} entries")
+
     # Create balanced dataset
     print(f"\nCreating balanced dataset with {args.n_per_class} proteins per {args.class_column}...")
     sampled_by_class, class_counts = create_balanced_dataset(
@@ -366,10 +390,17 @@ def main():
     # Save evaluation set
     eval_path = Path(args.eval_output)
     eval_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(eval_path, 'w') as f:
-        for identifier in eval_ids:
-            f.write(f"{identifier}\n")
-    print(f"Saved evaluation set to: {args.eval_output}")
+
+    if args.split_eval and args.split_eval > 1:
+        created_files = split_into_files(eval_ids, eval_path, args.split_eval)
+        print(f"\nSplit evaluation set into {len(created_files)} files:")
+        for f in created_files:
+            print(f"  {f}")
+    else:
+        with open(eval_path, 'w') as f:
+            for identifier in eval_ids:
+                f.write(f"{identifier}\n")
+        print(f"Saved evaluation set to: {args.eval_output}")
 
 
 if __name__ == '__main__':

--- a/scripts/v2/evaluate_methods_v2.py
+++ b/scripts/v2/evaluate_methods_v2.py
@@ -46,7 +46,7 @@ def lookup(df, filter_col, filter_val, value_col):
     return match.iloc[0] if not match.empty else None
 
 
-def calc_patk_mapk(results_df, label_df, top_k, query_id_fn=None):
+def calc_patk_mapk(results_df, label_df, top_k, query_id_fn=None, limit_to_ids=None):
     """Calculate Precision@K and MAP@K for a structural alignment results DataFrame.
 
     Column 0 is the query identifier; columns 1+ are retrieved target identifiers.
@@ -58,6 +58,8 @@ def calc_patk_mapk(results_df, label_df, top_k, query_id_fn=None):
         top_k: K for Precision@K and MAP@K.
         query_id_fn: Optional callable to transform the raw col-0 value into a
             pdb_id_chain key (e.g. stripping a filename suffix). Defaults to identity.
+        limit_to_ids: Optional set of pdb_id_chain strings. If provided, only rows
+            whose transformed query ID is in this set are evaluated.
 
     Returns:
         dict with keys patk_{fam,sfam,fold,class} and map_{fam,sfam,fold,class}.
@@ -68,13 +70,17 @@ def calc_patk_mapk(results_df, label_df, top_k, query_id_fn=None):
     levels = ('family', 'superfamily', 'fold', 'class')
     patk   = {lv: [] for lv in levels}
     mapk   = {lv: [] for lv in levels}
+    ratk   = {lv: [] for lv in levels}
     n_queries = 0
+    n_skipped = 0
 
     for i in range(results_df.shape[0]):
         query_id = query_id_fn(results_df.iloc[i, 0])
+        if limit_to_ids is not None and query_id not in limit_to_ids:
+            continue
         query_labels = {lv: lookup(label_df, 'pdb_id_chain', query_id, lv) for lv in levels}
         if any(v is None for v in query_labels.values()):
-            print(f'Query not found in labels: {query_id}')
+            n_skipped += 1
             continue
         n_queries += 1
 
@@ -84,8 +90,6 @@ def calc_patk_mapk(results_df, label_df, top_k, query_id_fn=None):
 
         k = 0
         for target in results_df.iloc[i, 1:]:
-            if target == query_id:
-                continue
             target_labels = {lv: lookup(label_df, 'pdb_id_chain', target, lv) for lv in levels}
             if any(v is None for v in target_labels.values()):
                 continue
@@ -94,15 +98,21 @@ def calc_patk_mapk(results_df, label_df, top_k, query_id_fn=None):
                 if query_labels[lv] == target_labels[lv]:
                     tp[lv] += 1
                     prec[lv] += tp[lv] / k
+            if k >= top_k:
+                break
 
         for lv in levels:
             patk[lv].append(tp[lv] / top_k)
             mapk[lv].append(prec[lv] / min(r[lv], top_k) if r[lv] > 0 else 0.0)
+            ratk[lv].append(tp[lv] / r[lv] if r[lv] > 0 else 0.0)
 
+    if n_skipped:
+        print(f'WARNING: {n_skipped} queries skipped (not found in label_df).')
     return {
         'n_queries': n_queries,
         **{f'patk_{lv}': np.mean(patk[lv]) for lv in levels},
         **{f'map_{lv}':  np.mean(mapk[lv])  for lv in levels},
+        **{f'ratk_{lv}': np.mean(ratk[lv])  for lv in levels},
     }
 
 
@@ -127,9 +137,11 @@ def read_gtalign_results(gtalign_results_dir):
                 if not m:
                     continue
                 rank = int(m.group(1))
-                if rank < 1 or rank > top_k:
+                if rank == 1 or rank > top_k+1:  # skip self-hit (rank 1) and anything beyond top_k
                     continue
                 path_m = path_re.search(line)
+                if not path_m:
+                    print(f'WARNING: no SCOPe domain ID found at rank {rank} in {os.path.basename(file)} — empty string appended.')
                 tmp.append(path_m.group(1) if path_m else '')
                 collected += 1
                 if collected >= top_k:
@@ -279,6 +291,12 @@ if __name__ == '__main__':
     precision_at_ks_sfams_map = []
     precision_at_ks_folds_map = []
     precision_at_ks_classes_map = []
+    recall_at_ks_fams = []
+    recall_at_ks_sfams = []
+    recall_at_ks_folds = []
+    recall_at_ks_classes = []
+    n_queries_skipped = 0
+    proteogram_evaluated_ids = set()
     for i in range(proteogram_res_df.shape[0]):
         prot_file = os.path.basename(proteogram_res_df.iloc[i,0])
         query_fam   = lookup(label_df, 'proteogram_file', prot_file, 'family')
@@ -286,8 +304,9 @@ if __name__ == '__main__':
         query_fold  = lookup(label_df, 'proteogram_file', prot_file, 'fold')
         query_class = lookup(label_df, 'proteogram_file', prot_file, 'class')
         if any(v is None for v in (query_fam, query_sfam, query_fold, query_class)):
-            print(f'Query not found in labels: {prot_file}')
+            n_queries_skipped += 1
             continue
+        proteogram_evaluated_ids.add(os.path.splitext(prot_file)[0])
         
         # Relevant item counts in corpus (excluding self) for MAP@K normalisation
         r_fam   = max((label_df['family'] == query_fam).sum() - 1, 0)
@@ -337,6 +356,8 @@ if __name__ == '__main__':
             if query_class == target_class:
                 tp_class += 1
                 prec_at_k_class += (tp_class / k)
+            if k >= top_k:
+                break
 
         # For Precision@K
         precision_at_ks_fams.append(tp_fam/top_k)
@@ -349,6 +370,12 @@ if __name__ == '__main__':
         precision_at_ks_sfams_map.append(prec_at_k_sfam / min(r_sfam, top_k) if r_sfam > 0 else 0.0)
         precision_at_ks_folds_map.append(prec_at_k_fold / min(r_fold, top_k) if r_fold > 0 else 0.0)
         precision_at_ks_classes_map.append(prec_at_k_class / min(r_class, top_k) if r_class > 0 else 0.0)
+
+        # For Recall@K: tp / R
+        recall_at_ks_fams.append(tp_fam / r_fam if r_fam > 0 else 0.0)
+        recall_at_ks_sfams.append(tp_sfam / r_sfam if r_sfam > 0 else 0.0)
+        recall_at_ks_folds.append(tp_fold / r_fold if r_fold > 0 else 0.0)
+        recall_at_ks_classes.append(tp_class / r_class if r_class > 0 else 0.0)
 
         # Save images of those with no/full agreement at the configured scope_level
         stem = os.path.splitext(os.path.basename(prot_file))[0]
@@ -372,6 +399,9 @@ if __name__ == '__main__':
                                      to_copy),
                                      os.path.join(save_good_searches_dir, to_copy.replace('top_sims', f'top_sims_{query_level}_pk{score_for_top_sims:.4f}')))
 
+    if n_queries_skipped:
+        print(f'WARNING: {n_queries_skipped} proteogram queries skipped (not found in label_df).')
+
     proteogram_patk_fam = np.mean(precision_at_ks_fams)
     proteogram_patk_sfam = np.mean(precision_at_ks_sfams)
     proteogram_patk_fold = np.mean(precision_at_ks_folds)
@@ -380,6 +410,10 @@ if __name__ == '__main__':
     proteogram_map_sfam = np.mean(precision_at_ks_sfams_map)
     proteogram_map_fold = np.mean(precision_at_ks_folds_map)
     proteogram_map_class = np.mean(precision_at_ks_classes_map)
+    proteogram_ratk_fam = np.mean(recall_at_ks_fams)
+    proteogram_ratk_sfam = np.mean(recall_at_ks_sfams)
+    proteogram_ratk_fold = np.mean(recall_at_ks_folds)
+    proteogram_ratk_class = np.mean(recall_at_ks_classes)
 
     # Calculate Precision@K's and MAP@K's
     gtalign_res_df = read_gtalign_results(gtalign_results_dir)
@@ -388,21 +422,38 @@ if __name__ == '__main__':
                           sep='\t', index=False)
     gtalign_metrics = calc_patk_mapk(
         gtalign_res_df, label_df, top_k,
-        query_id_fn=lambda x: x.replace('.ent.out', '').replace('.out', '')[:7])
+        query_id_fn=lambda x: x.replace('.ent.out', '').replace('.out', '')[:7],
+        limit_to_ids=proteogram_evaluated_ids)
 
     usalign_res_df = read_usalign_results(usalign_results)
-    usalign_metrics = calc_patk_mapk(usalign_res_df, label_df, top_k)
+    usalign_metrics = calc_patk_mapk(usalign_res_df, label_df, top_k,
+                                     limit_to_ids=proteogram_evaluated_ids)
 
     gt = gtalign_metrics
     us = usalign_metrics
     proteogram_n = len(precision_at_ks_fams)
     print(f'Proteins compared — Proteogram: {proteogram_n} | GTalign: {gt["n_queries"]} | USalign: {us["n_queries"]}')
-    print('Measure                       | Proteogram  | GTalign     | USalign    |')
-    print(f'Precision@K for families      | {proteogram_patk_fam:.4f}      | {gt["patk_family"]:.4f}      | {us["patk_family"]:.4f}')
-    print(f'Precision@K for superfamilies | {proteogram_patk_sfam:.4f}      | {gt["patk_superfamily"]:.4f}      | {us["patk_superfamily"]:.4f}')
-    print(f'Precision@K for folds         | {proteogram_patk_fold:.4f}      | {gt["patk_fold"]:.4f}      | {us["patk_fold"]:.4f}')
-    print(f'Precision@K for classes       | {proteogram_patk_class:.4f}      | {gt["patk_class"]:.4f}      | {us["patk_class"]:.4f}')
-    print(f'MAP@K for families            | {proteogram_map_fam:.4f}      | {gt["map_family"]:.4f}      | {us["map_family"]:.4f}')
-    print(f'MAP@K for superfamilies       | {proteogram_map_sfam:.4f}      | {gt["map_superfamily"]:.4f}      | {us["map_superfamily"]:.4f}')
-    print(f'MAP@K for folds               | {proteogram_map_fold:.4f}      | {gt["map_fold"]:.4f}      | {us["map_fold"]:.4f}')
-    print(f'MAP@K for classes             | {proteogram_map_class:.4f}      | {gt["map_class"]:.4f}      | {us["map_class"]:.4f}')
+
+    hdr  = f'{"Method":<15} | {"Class":>8} | {"Fold":>8} | {"Superfamily":>11} | {"Family":>8}'
+    sep  = '-' * len(hdr)
+
+    print(f'\nPrecision@K (K={top_k})')
+    print(hdr)
+    print(sep)
+    print(f'{"GTalign":<15} | {gt["patk_class"]:>8.4f} | {gt["patk_fold"]:>8.4f} | {gt["patk_superfamily"]:>11.4f} | {gt["patk_family"]:>8.4f}')
+    print(f'{"USalign":<15} | {us["patk_class"]:>8.4f} | {us["patk_fold"]:>8.4f} | {us["patk_superfamily"]:>11.4f} | {us["patk_family"]:>8.4f}')
+    print(f'{"Proteogram":<15} | {proteogram_patk_class:>8.4f} | {proteogram_patk_fold:>8.4f} | {proteogram_patk_sfam:>11.4f} | {proteogram_patk_fam:>8.4f}')
+
+    print(f'\nMAP@K (K={top_k})')
+    print(hdr)
+    print(sep)
+    print(f'{"GTalign":<15} | {gt["map_class"]:>8.4f} | {gt["map_fold"]:>8.4f} | {gt["map_superfamily"]:>11.4f} | {gt["map_family"]:>8.4f}')
+    print(f'{"USalign":<15} | {us["map_class"]:>8.4f} | {us["map_fold"]:>8.4f} | {us["map_superfamily"]:>11.4f} | {us["map_family"]:>8.4f}')
+    print(f'{"Proteogram":<15} | {proteogram_map_class:>8.4f} | {proteogram_map_fold:>8.4f} | {proteogram_map_sfam:>11.4f} | {proteogram_map_fam:>8.4f}')
+
+    print(f'\nRecall@K (K={top_k})')
+    print(hdr)
+    print(sep)
+    print(f'{"GTalign":<15} | {gt["ratk_class"]:>8.4f} | {gt["ratk_fold"]:>8.4f} | {gt["ratk_superfamily"]:>11.4f} | {gt["ratk_family"]:>8.4f}')
+    print(f'{"USalign":<15} | {us["ratk_class"]:>8.4f} | {us["ratk_fold"]:>8.4f} | {us["ratk_superfamily"]:>11.4f} | {us["ratk_family"]:>8.4f}')
+    print(f'{"Proteogram":<15} | {proteogram_ratk_class:>8.4f} | {proteogram_ratk_fold:>8.4f} | {proteogram_ratk_sfam:>11.4f} | {proteogram_ratk_fam:>8.4f}')

--- a/scripts/v2/measure_similarity_v2.py
+++ b/scripts/v2/measure_similarity_v2.py
@@ -17,7 +17,7 @@ from proteogram.v2 import Img2Vec
 from proteogram.common import read_yaml
 
 
-def pad_to_200(img, target=200, fill=128):
+def pad_to_size(img, target=200, fill=128):
     """Pad a PIL image to target×target with gray (matching training script).
 
     Images smaller than target are center-padded; images larger are cropped
@@ -117,7 +117,7 @@ if __name__ == '__main__':
     img_sim = Img2Vec(model_file, dataset_dir=prot_files, weights='DEFAULT', device=device)
     # Override transform to match training: pad to 200x200 with gray rather than resize
     img_sim.transform = transforms.Compose([
-        transforms.Lambda(pad_to_200),
+        transforms.Lambda(pad_to_size(target=200)),
         transforms.ToTensor(),
         transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
     ])
@@ -137,24 +137,34 @@ if __name__ == '__main__':
                 with open(embed_file, 'rb') as pklin:
                     img_sim.dataset = pickle.load(pklin)
             
-        # Search to find similar images using cosine-similarity amongst embeddings
-        # Save search results as images (TOP_K) to save_images_dir
+        # Search to find similar images using cosine-similarity amongst embeddings.
+        # Save all corpus results (including self-hit) so Recall@K can be computed at
+        # any K and with/without self-hit at eval time.
+        # Image saving is done separately at top_k to avoid PIL's 65500px dimension limit.
         start = time()
-        sim_time = img_sim.similarities(n=top_k,
-                                        save_result_images_dir=save_images_dir,
-                                        pad_fn=pad_to_200)
-        
+        n_results = len(prot_files)  # all including self-hit
+        sim_time = img_sim.similarities(n=n_results,
+                                        save_result_images_dir=None,
+                                        pad_fn=pad_to_size)
+
+        # Save top-k result images with padding
+        full_sim_dict = {k: list(v) for k, v in img_sim.sim_dict.items()}
+        for image_path in img_sim.sim_dict:
+            img_sim.sim_dict[image_path] = full_sim_dict[image_path][:top_k]
+            img_sim.save_images(image_path, save_images_dir, pad_fn=pad_to_size)
+        img_sim.sim_dict = full_sim_dict  # restore all results for CSV
+
         print(f'Took {sim_time} seconds to calculate similarities / perform search.')
         print(f'Took {time()-start} seconds overall (including optional image result saving).')
 
         # Create dataframe of results
-        scores_tmp = [[''] * top_k] * len(prot_files)
-        df_res = pd.DataFrame(scores_tmp, columns=[[str(i) for i in range(top_k)]])
+        scores_tmp = [[''] * n_results] * len(prot_files)
+        df_res = pd.DataFrame(scores_tmp, columns=[[str(i) for i in range(n_results)]])
         df_res['query_image'] = prot_files
         for i, image_path in enumerate(prot_files):
             try:
                 scores = img_sim.sim_dict[image_path]
-                df_res.iloc[i, :top_k] = [f'{a},{b}' for (a, b) in scores]
+                df_res.iloc[i, :n_results] = [f'{a},{b}' for (a, b) in scores]
             except KeyError as e:
                 print(f'Key error for {e}')
         # Reorder cols

--- a/scripts/v2/train_multiple_models.py
+++ b/scripts/v2/train_multiple_models.py
@@ -547,13 +547,13 @@ if __name__ == '__main__':
 
     image_resize = 200  # pad to largest possible size; GAP makes the FC layer size-agnostic
 
-    # ResNet18 was trained with ImageNet normalisation — apply the same preprocessing
+    # ResNet18 was trained with ImageNet normalisation (standardize input images to the same distribution as the data the model was pre-trained on)
     # so the pretrained feature detectors remain valid. The ConvNet was not pretrained, so it doesn't strictly require ImageNet normalisation, but applying the same normalisation to both models allows for a more controlled comparison.
     _imagenet_norm = transforms.Normalize(mean=[0.485, 0.456, 0.406],
                                           std=[0.229, 0.224, 0.225])
     _augment = [
-        transforms.RandomApply([transforms.ColorJitter(brightness=0.1, contrast=0.1)], p=0.2),
-        transforms.RandomApply([transforms.RandomAdjustSharpness(sharpness_factor=2)], p=0.2),
+        transforms.RandomApply([transforms.ColorJitter(brightness=0.1, contrast=0.1)], p=0.1),
+        transforms.RandomApply([transforms.RandomAdjustSharpness(sharpness_factor=2)], p=0.1),
     ]
 
     if args.model == 'resnet18':


### PR DESCRIPTION
Fixes/updates:

- Added an argument when creating balanced training and eval lists based on SCOPe ontologies, that splits the eval lists as well optionally (so that these too can be run in parallel)
- Added recall@k as a metric to the evaluate v2 script and thus get all search results from the measure similarity v2 script
- Deal better with the self-hit (top hit for Proteogram and GTalign both have self-hit returned at rank 1, but US-align does not return self-hit) - solution is to exclude self-hit now from eval metric calculations for a fairer comparison (e.g., if K=5, compare top 5 without self-hit for all methods)
- In evals, uses the exact same set of proteins in calculating metrics for all methods for fairer comparison (before, we were using all available eval structures for the structure-alignment based approaches, but Proteograms could be less due to MD simulation issues or protein size filters)
- Now deal with most common post-translational modifications (PTMs) on residues in pre-processing before simulations (we convert common PTMs to standard amino acids now so the AMBER forcefield can be applied)
- Fix the NPT equilibration to leverage the custom forces on c-alpha backbone correctly when using periodic box conditions (PBCs) and barostats (using Cartesian harmonic a `CustomExternalForce`) which eliminates the gradient discontinuity at box boundaries
- Fix NPT equilibration to let OpenMM set velocities (velocity initialization) to the specific temperature with `setVelocitiesToTemperature(self.temperature)`
- Fix NPT to update CA restraint reference positions to track NPT barostat coordinate rescaling — prevents growing forces from position/box mismatch
- When initializing the Proteogram v2, get the first chain from PDB file from the PDBParser structure model (`model.get_chains().__next__()`) instead of the script passing in the chain ID from parsing the file name (since this would break the pipeline if not using the SCOPe-downloaded filenames)
- Changed the image augmentation probability to 10% from 20% so that image augmentation is applied only 10% of the time (in the future this could be a tunable parameter)