### PR TITLE
Fix for cuda in single search and save images method

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,12 @@ cp scripts/v2/config.example.yml scripts/v2/config.yml
 
 All scripts read from `scripts/v2/config.yml`. The keys used at each pipeline step are listed below alongside the relevant step. A full reference is in `scripts/v2/config.example.yml`.
 
-### Single protein inference
+### Single protein inference demo
 
-`query_similar_proteins.py` takes a single PDB file, builds its v2 proteogram (running the full MD simulation pipeline), embeds it with the trained model, and returns the top-K most similar proteins from a pre-computed corpus using cosine similarity.
+`query_similar_proteins.py`, a demo of the project inference workflow, takes a single PDB file, builds its v2 proteogram (running the full MD simulation pipeline and saving refined structure), embeds it with the trained model, and returns the top-K most similar proteins from a pre-computed corpus using cosine similarity. 
+
+> [!NOTE]
+> The provided embeddings are a small demo corpus, not a comprehensive PDB dataset. This script demonstrates the retrieval workflow only — results will not reflect full PDB coverage.
 
 **Prerequisites:**
 
@@ -149,8 +152,8 @@ All scripts read from `scripts/v2/config.yml`. The keys used at each pipeline st
 
 **Add the following to `scripts/v2/config.yml`** if not already present:
 ```yaml
-model_file: /path/to/proteogram_resnet18_finetuned_lr0.001_bs8_e29_85.5acc.pt
-embed_file: /path/to/proteogram_embeddings_scope2.08-nr60_20-200.pkl
+model_file: /path/to/proteogram_demo_resnet18_finetuned_lr0.001_bs8_e29_85.5acc.pt
+embed_file: /path/to/proteogram_demo_embeddings_scope2.08-nr60_20-200.pkl
 top_k: 5
 proteograms_for_sim_dir: /path/to/corpus/proteogram/images  # optional: parent or root dir containing corpus .jpg files (searched recursively)
 ```
@@ -180,7 +183,9 @@ Arguments:
 - A side-by-side result image saved to `<output_dir>/search_results/`
 
 
-### v2 End-to-End Pipeline
+### v2 End-to-End Train and Eval Pipeline
+
+This workflow is meant to provide instruction on creating a database of Proteograms, training an Img2Vec model, create a corpus of Proteogram embeddings, and evaluating the Proteogram approach against other popular structure search tools.
 
 All commands below are run from the `scripts/v2/` directory:
 ```bash
@@ -210,6 +215,8 @@ Key optional flags:
 - `--memory-efficient`: Lower peak RAM at the cost of speed (for proteins > ~150 residues on constrained hardware)
 
 > Proteogram creation runs the full MD simulation pipeline (energy minimization + equilibration + 1 ns production). Expect ~5 min per protein for small domains (~50 residues) and ~1 hour for larger ones (~200 residues) on a GPU. Run multiple instances in parallel with `--limit_file` splits to speed this up.
+
+This step may be used to create a single Proteogram as well for inference (including an option to save the refined structure file from the MD simulation).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This representation captures both spatial similarity through distograms and phys
 
 Example proteogram v1 (symmetric):
 
-![](assets/3KFD_A.jpg)
+![](assets/figures/3KFD_A.jpg)
 
 ### Proteogram v2: Incorporating MD Simulations
 
@@ -51,7 +51,7 @@ All six maps are normalized to [0–255] before combining into the final RGB ima
 
 Example Proteogram v2 (asymmetric):
 
-![](assets/d3kfda_.jpg)
+![](assets/figures/d3kfda_.jpg)
 
 ## Getting started with Proteogram v2
 
@@ -138,7 +138,49 @@ cp scripts/v2/config.example.yml scripts/v2/config.yml
 
 All scripts read from `scripts/v2/config.yml`. The keys used at each pipeline step are listed below alongside the relevant step. A full reference is in `scripts/v2/config.example.yml`.
 
-### v2 Pipeline
+### Single protein inference
+
+`query_similar_proteins.py` takes a single PDB file, builds its v2 proteogram (running the full MD simulation pipeline), embeds it with the trained model, and returns the top-K most similar proteins from a pre-computed corpus using cosine similarity.
+
+**Prerequisites:**
+
+1. A trained PyTorch CNN (`.pt` file) — produced by `train_multiple_models.py` and set as `model_file` in `config.yml`. For the benchmarking model, go to the Releases in this repository and download from the latest release.
+2. A pre-computed corpus embedding pickle — produced by running `measure_similarity_v2.py` at least once, set as `embed_file` in `config.yml`. For the benchmarking embeddings, go to the Releases in this repository and download from the latest release.
+
+**Add the following to `scripts/v2/config.yml`** if not already present:
+```yaml
+model_file: /path/to/proteogram_resnet18_finetuned_lr0.001_bs8_e29_85.5acc.pt
+embed_file: /path/to/proteogram_embeddings_scope2.08-nr60_20-200.pkl
+top_k: 5
+proteograms_for_sim_dir: /path/to/corpus/proteogram/images  # optional: parent or root dir containing corpus .jpg files (searched recursively)
+```
+
+> **Note:** `proteograms_for_sim_dir` is optional (allows the retrieval of the actual images themselves to built a composite image with query and targets). Set it to any directory that contains (or recursively contains) the corpus proteogram `.jpg` files. Without it, the side-by-side result image will show only the query proteogram, since the matching corpus images cannot be located on disk.
+
+
+**Run from the `scripts/v2/` folder (Note, this may take a very long time depending upon the size of the protein which will, if large, make the MD simulation very compute intensive):**
+```bash
+cd scripts/v2
+python query_similar_proteins.py \
+  --pdb_file /path/to/myprotein.pdb \
+  --chain_id A \
+  --output_dir /path/to/results \
+  --top_k 5
+```
+
+Arguments:
+- `--pdb_file / -p`: Path to the query PDB file (required)
+- `--chain_id / -c`: Chain ID to extract, e.g. `A` (required)
+- `--output_dir / -o`: Directory to save the query proteogram JPG and result images (default: current directory)
+- `--top_k / -k`: Number of top results to return (default: `top_k` from `config.yml`)
+
+**Output:**
+- The query proteogram saved as `<pdb_basename>.jpg` in `--output_dir`
+- A ranked list of top-K similar proteins with cosine similarity scores printed to the console
+- A side-by-side result image saved to `<output_dir>/search_results/`
+
+
+### v2 End-to-End Pipeline
 
 All commands below are run from the `scripts/v2/` directory:
 ```bash
@@ -345,43 +387,6 @@ Key optional flags:
 
 Outputs Precision@K, MAP@K, and Recall@K for each method (Proteogram, GTalign, USalign and optionally Foldseek) at the structure class and fold levels.
 
-### Find similar proteins to a single domain
-
-`query_similar_proteins.py` takes a single PDB file, builds its v2 proteogram (running the full MD simulation pipeline), embeds it with the trained model, and returns the top-K most similar proteins from a pre-computed corpus using cosine similarity.
-
-**Prerequisites:**
-
-1. A trained PyTorch CNN (`.pt` file) — produced by `train_multiple_models.py` and set as `model_file` in `config.yml`. For the benchmarking model, go to the Releases in this repository and download from the latest release.
-2. A pre-computed corpus embedding pickle — produced by running `measure_similarity_v2.py` at least once, set as `embed_file` in `config.yml`. For the benchmarking embeddings, go to the Releases in this repository and download from the latest release.
-
-**Add the following to `scripts/v2/config.yml`** if not already present:
-```yaml
-model_file: /path/to/proteogram_resnet18_finetuned_lr0.001_bs8_e29_85.5acc.pt
-embed_file: /path/to/proteogram_embeddings_scope2.08-nr60_20-200.pkl
-top_k: 5
-```
-
-**Run from the `scripts/v2/` folder (Note, this may take a very long time depending upon the size of the protein which will, if large, make the MD simulation very compute intensive):**
-```bash
-cd scripts/v2
-python query_similar_proteins.py \
-  --pdb_file /path/to/myprotein.pdb \
-  --chain_id A \
-  --output_dir /path/to/results \
-  --top_k 5
-```
-
-Arguments:
-- `--pdb_file / -p`: Path to the query PDB file (required)
-- `--chain_id / -c`: Chain ID to extract, e.g. `A` (required)
-- `--output_dir / -o`: Directory to save the query proteogram JPG and result images (default: current directory)
-- `--top_k / -k`: Number of top results to return (default: `top_k` from `config.yml`)
-
-**Output:**
-- The query proteogram saved as `<pdb_basename>.jpg` in `--output_dir`
-- A ranked list of top-K similar proteins with cosine similarity scores printed to the console
-- A side-by-side result image saved to `<output_dir>/search_results/`
-
 ### Running an MD simulation (without creating a Proteogram)
 
 The `NonBondedForceModel` module provides a complete pipeline for running molecular dynamics simulations by themselves and calculating residue-residue interaction energies (Van der Waals and electrostatics). Here's an example:
@@ -434,7 +439,7 @@ The `v1` and `v2` subfolders have their own `config.yml` (copy from the correspo
 | Script | Purpose | Config Variables (`config.yml`) | Command-Line Arguments |
 |--------|---------|--------------------------------|------------------------|
 | `v2/create_v2_proteograms.py` | Create proteograms using MD-based nonbonded energy calculations, distances, and hydrophobicity deltas | `limit_file`, `scope_structures_dir`, `all_proteograms_dir` | `--max_workers/-w`, `--overwrite`, `--verbose`, `--debug`, `--memory-efficient`, `--save_simulated_pdb` |
-| `v2/query_similar_proteins.py` | Create a proteogram for a single query PDB and find the top-K most similar proteins from a pre-computed corpus | `top_k`, `model_file`, `embed_file` | `--pdb_file/-p`, `--chain_id/-c`, `--output_dir/-o`, `--top_k/-k` |
+| `v2/query_similar_proteins.py` | Create a proteogram for a single query PDB and find the top-K most similar proteins from a pre-computed corpus | `top_k`, `model_file`, `embed_file`, `proteograms_for_sim_dir` (optional — parent or root directory containing corpus `.jpg` files, searched recursively, needed for result image) | `--pdb_file/-p`, `--chain_id/-c`, `--output_dir/-o`, `--top_k/-k` |
 | `v2/measure_similarity_v2.py` | Batch similarity search across all proteograms | `top_k`, `model_file`, `embed_file`, `proteogram_sim_results`, `proteograms_for_sim_dir`, `search_images_dir` | `--exclude_classes/-x`, `--overwrite`, `--embed/--no-embed` |
 | `v2/train_multiple_models.py` | Train a from-scratch ConvNet or fine-tune ResNet18 for proteogram classification, with early stopping and per-class evaluation | `training_data_dir`, `num_epochs`, `learning_rate`, `batch_size`, `scope_level`, `model_file_prefix` | `--data_dir/-d` (overrides `training_data_dir`), `--epochs/-e`, `--batch_size/-b`, `--lr/-l`, `--model/-m` (`cnn`\|`resnet18`), `--level` (`class`\|`fold`\|`superfamily`\|`family`, default: `class`), `--tsv_file/-t`, `--patience`, `--val_size`, `--exclude_classes/-x`, `--overwrite/-o`, `--resize`, `--verbose/-v` |
 | `v2/evaluate_methods_v2.py` | Evaluate proteogram approach vs GTalign, USalign, and Foldseek | `top_k`, `scope_eval_set`, `proteogram_sim_results`, `gtalign_results_dir`, `usalign_results`, `foldseek_results` (optional), `search_images_dir`, `save_bad_searches_dir`, `save_good_searches_dir`, `scope_cla_file`, `scope_des_file`, `scope_hie_file` | `--overwrite`, `--exclude_classes/-x` |

--- a/proteogram/v2/image_similarity.py
+++ b/proteogram/v2/image_similarity.py
@@ -497,9 +497,36 @@ class Img2Vec:
             scores = ['']
             scores.extend([f'{score:.2f}' for _, score in scores_n_arr])
         if corpus_dir:
-            result_paths = [os.path.join(corpus_dir, os.path.basename(k)) for k in result_keys]
+            # Build a recursive filename→path index so subdirectory layouts are found.
+            corpus_index = {
+                os.path.basename(p): p
+                for p in glob.glob(os.path.join(corpus_dir, '**', '*.jpg'), recursive=True)
+            }
+            corpus_index.update({
+                os.path.basename(p): p
+                for p in glob.glob(os.path.join(corpus_dir, '**', '*.png'), recursive=True)
+            })
+            result_paths = [
+                corpus_index.get(os.path.basename(k), os.path.join(corpus_dir, os.path.basename(k)))
+                for k in result_keys
+            ]
         else:
             result_paths = result_keys
+
+        # Filter to files that actually exist; warn about missing ones
+        available = [(p, s) for p, s in zip(result_paths, scores[1:]) if os.path.isfile(p)]
+        missing = [p for p in result_paths if not os.path.isfile(p)]
+        if missing:
+            print(f'Warning: {len(missing)} result image(s) not found on disk and will be skipped.')
+            print(f'  Set proteograms_for_sim_dir in config.yml to the local corpus image directory.')
+        result_paths = [p for p, _ in available]
+        scores = [''] + [s for _, s in available]
+
+        if not os.path.isfile(query_file):
+            raise FileNotFoundError(
+                f'Query proteogram image not found: {query_file}\n'
+                f'Ensure the proteogram was saved successfully before calling save_images.')
+
         images_files = [query_file] + result_paths
         images = [pad_fn(Image.open(t)) if pad_fn else Image.open(t) for t in images_files]
 

--- a/proteogram/v2/nonbonded_forces.py
+++ b/proteogram/v2/nonbonded_forces.py
@@ -506,17 +506,19 @@ class NonBondedForceModel:
         )
         
         platform = self._get_platform()
-        
+        platform_properties = {'CudaPrecision': 'double'} if platform.getName() == 'CUDA' else {}
+
         # Clean up old simulation to free memory (especially CUDA)
         self.cleanup_all_resources(final_run=False)
-        
+
         # Don't store system here - Simulation manages its own system lifetime
         # Create fresh system for this simulation
         self.simulation = Simulation(
             self.topology,
             system,
             integrator,
-            platform
+            platform,
+            platform_properties
         )
         
         # Restore periodic box vectors from previous Context if available

--- a/proteogram/v2/nonbonded_forces.py
+++ b/proteogram/v2/nonbonded_forces.py
@@ -467,7 +467,7 @@ class NonBondedForceModel:
         )
         
         if add_barostat:
-            barostat = MonteCarloBarostat(self.pressure, self.temperature)
+            barostat = MonteCarloBarostat(self.pressure, self.temperature, 100)
             system.addForce(barostat)  # FIX: Use new 'system' not 'self.system'
 
         if add_calpha_restraint:
@@ -506,7 +506,7 @@ class NonBondedForceModel:
         )
         
         platform = self._get_platform()
-        platform_properties = {'CudaPrecision': 'double'} if platform.getName() == 'CUDA' else {}
+        platform_properties = {'CudaPrecision': 'mixed'} if platform.getName() == 'CUDA' else {}
 
         # Clean up old simulation to free memory (especially CUDA)
         self.cleanup_all_resources(final_run=False)
@@ -1127,10 +1127,10 @@ class NonBondedForceModel:
             report_interval (int): Interval for reporting state data.
         """
         print(f"Running NPT equilibration for {steps} steps...")
-        
+
         # Store positions before NPT as backup
         self._pre_npt_positions = self.positions
-        
+
         # Create simulation with barostat
         self._create_new_simulation(
             add_calpha_restraint=True,
@@ -1152,7 +1152,7 @@ class NonBondedForceModel:
                 separator='\t'
             )
         )
-        
+
         # Get initial energy for monitoring
         n_atoms = self._get_n_atoms()
         initial_state = self.simulation.context.getState(getEnergy=True)
@@ -1160,8 +1160,8 @@ class NonBondedForceModel:
         del initial_state  # CRITICAL: Delete state to avoid holding Context reference
         print(f"  Initial potential energy: {initial_energy:.1f} kJ/mol "
             f"({initial_energy/n_atoms:.2f} kJ/mol/atom)")
-        
-        # Track energies for validation
+
+        # Track energies for validation — seed with None so the first chunk is not
         energy_history = [initial_energy]
         check_interval = max(steps // 5, report_interval)  # Check 5 times during equilibration
         
@@ -1200,10 +1200,11 @@ class NonBondedForceModel:
                 time_ps = steps_run * timestep_ps
                 self._log_energy('npt', time_ps, current_energy)
             
-            # Validate energy
+            # Validate energy — skip comparing chunk 1 against pre-velocity initial
+            # energy since that jump is expected when velocities are assigned at 310K.
             warnings_list = self._validate_energy(
-                current_energy, 'NPT', 
-                prev_energy=energy_history[-2] if len(energy_history) > 1 else None,
+                current_energy, 'NPT',
+                prev_energy=energy_history[-2] if len(energy_history) > 2 else None,
                 n_atoms=n_atoms
             )
             for w in warnings_list:
@@ -1245,7 +1246,6 @@ class NonBondedForceModel:
                 raise RuntimeError("NPT equilibration corrupted positions and no backup available")
             
         self.cleanup_all_resources(final_run=False)
-
         print("NPT equilibration complete.")
 
     def equilibrate_nvt(

--- a/scripts/v2/query_similar_proteins.py
+++ b/scripts/v2/query_similar_proteins.py
@@ -10,6 +10,11 @@ Prerequisites:
 
 Usage example:
     python query_similar_proteins.py --pdb_file /path/to/protein.pdb --chain_id A
+
+Note:
+  - May need to choose a different version of PyTorch with the proper CUDA support if you encounter CUDA errors.
+    - Try: pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121
+  - The output image will show the query proteogram and the top-K similar proteograms side by side, with cosine similarity scores annotated.
 """
 import argparse
 import gc
@@ -21,6 +26,7 @@ import matplotlib
 matplotlib.use('agg')
 import matplotlib.pyplot as plt
 import torch
+torch.backends.cudnn.enabled = False
 import torch.nn as nn
 import torchvision.transforms as transforms
 from Bio.PDB.PDBParser import PDBConstructionWarning
@@ -69,14 +75,22 @@ if __name__ == '__main__':
 
     config = read_yaml('config.yml')
     top_k      = args.top_k or config['top_k']
-    model_file = config['model_file']
-    embed_file = config['embed_file']
+    model_file = os.path.expanduser(config['model_file'])
+    embed_file = os.path.expanduser(config['embed_file'])
     corpus_dir = config.get('proteograms_for_sim_dir')
+    if corpus_dir:
+        corpus_dir = os.path.expanduser(corpus_dir)
 
+    args.output_dir = os.path.expanduser(args.output_dir)
     os.makedirs(args.output_dir, exist_ok=True)
 
     # --- Step 1: Create the proteogram from the query PDB ---
-    use_gpu = torch.cuda.is_available()
+    try:
+        from openmm import Platform
+        _openmm_platforms = [Platform.getPlatform(i).getName() for i in range(Platform.getNumPlatforms())]
+        use_gpu = 'CUDA' in _openmm_platforms
+    except Exception:
+        use_gpu = False
     print(f'Creating proteogram for {args.pdb_file} (chain {args.chain_id})...')
 
     proteogram = ProteogramV2(
@@ -107,6 +121,8 @@ if __name__ == '__main__':
     plt.close('all')
     del proteogram, final_data
     gc.collect()
+    if not os.path.isfile(query_jpg):
+        raise RuntimeError(f'Failed to save query proteogram — file not found after imsave: {query_jpg}')
     print(f'Saved query proteogram to {query_jpg}')
 
     # --- Step 2: Load corpus embeddings and embed the query image ---
@@ -134,11 +150,21 @@ if __name__ == '__main__':
     scores = []
     with torch.no_grad():
         for path, emb in corpus.items():
-            sim = cosine(query_vec, emb)[0].item()
+            sim = cosine(query_vec, emb.to(query_vec.device))[0].item()
             scores.append((path, sim))
 
     scores.sort(key=lambda x: x[1], reverse=True)
-    top_results = scores[:top_k]
+
+    # Exclude the query protein itself if it appears in the corpus.
+    query_basename = os.path.basename(query_jpg)
+    scores_filtered = [(p, s) for p, s in scores
+                       if os.path.basename(p) != query_basename]
+    top_results = scores_filtered[:top_k]
+
+    if corpus_dir is None:
+        print('Warning: proteograms_for_sim_dir not set in config.yml — '
+              'result images will not be shown. Set it to the directory '
+              'containing the corpus proteogram JPG files.')
 
     # --- Step 4: Print results and save result image ---
     print(f'\nTop {top_k} similar proteins:')
@@ -147,5 +173,6 @@ if __name__ == '__main__':
 
     result_img_dir = os.path.join(args.output_dir, 'search_results')
     os.makedirs(result_img_dir, exist_ok=True)
-    img_sim.save_images(query_jpg, result_img_dir, scores_n_arr=top_results, corpus_dir=corpus_dir)
+    img_sim.save_images(query_jpg, result_img_dir, scores_n_arr=top_results, corpus_dir=corpus_dir,
+                        pad_fn=pad_to_size)
     print(f'\nResult image saved to {result_img_dir}/')


### PR DESCRIPTION
- Small change in `v2/image_similarity.py` for saving similar images from a single proteogram inference/search script
- Fix for setting cuda as platform in new simulation in `v2/nonbonded_forces.py`
- Better instruction on single protein inference in README 
- Also, fix two image paths in README
- Updated the `MonteCarloBarostat` frequency in the NPT equilibrium phase from the default of every 25 steps to 100 steps to help prevent NaN explosions in small solvated systems